### PR TITLE
Layout: highlight focused tree item, close issue details on logout

### DIFF
--- a/signal0ne/package.json
+++ b/signal0ne/package.json
@@ -56,7 +56,6 @@
       "view/item/context": [
         {
           "command": "signal0ne.issueFocus",
-          "group": "inline",
           "when": "view == signal0neIssue && viewItem == 'issue'"
         }
       ]

--- a/signal0ne/src/components/issuesTreeView.ts
+++ b/signal0ne/src/components/issuesTreeView.ts
@@ -114,11 +114,6 @@ export class IssuesTreeDataProvider
         return {
           ...commonTreeItemProps,
           collapsibleState: vscode.TreeItemCollapsibleState.None,
-          command: {
-            arguments: [element],
-            command: 'signal0ne.issueFocus',
-            title: 'Focus Issue'
-          },
           contextValue: 'issue'
         };
       default:
@@ -137,6 +132,7 @@ export class IssuesTreeDataProvider
 export class IssuesTreeView {
   private issuesTreeDataProvider: IssuesTreeDataProvider;
   private signal0neProvider: Signal0neProvider;
+  private treeView: vscode.TreeView<IssueTreeDataNode>;
 
   constructor(
     _context: vscode.ExtensionContext,
@@ -156,8 +152,19 @@ export class IssuesTreeView {
       }
     );
 
-    vscode.window.createTreeView('signal0neIssue', {
+    this.treeView = vscode.window.createTreeView('signal0neIssue', {
       treeDataProvider: this.issuesTreeDataProvider
+    });
+
+    this.treeView.onDidChangeSelection(async e => {
+      if (e.selection && e.selection.length > 0) {
+        await vscode.commands.executeCommand(
+          'signal0ne.issueFocus',
+          e.selection[0]
+        );
+      } else {
+        createIssueDetailsView({} as Issue, this.signal0neProvider, true);
+      }
     });
   }
 

--- a/signal0ne/src/extension.ts
+++ b/signal0ne/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { AuthTreeView } from './components/authTreeView';
+import { issueDetailsSidePanel } from './components/issueDetailsView';
 import { IssuesTreeView } from './components/issuesTreeView';
 import { Signal0neProvider } from './auth/signal0ne.provider';
 
@@ -70,6 +71,10 @@ export async function activate(context: vscode.ExtensionContext) {
     authTreeView.authTreeViewRef.title = 'Signal0ne';
     authTreeView.setShowAccountTreeItems(false);
     issuesTreeView = null;
+
+    if (issueDetailsSidePanel) {
+      issueDetailsSidePanel.dispose();
+    }
 
     clearInterval(refreshIssuesInterval);
   };
@@ -147,4 +152,8 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 }
 
-export function deactivate() {}
+export function deactivate() {
+  // if (issueDetailsSidePanel) {
+  //   issueDetailsSidePanel.dispose();
+  // }
+}


### PR DESCRIPTION
Changes:
- highlight focused issue
- hide the issue details panel after clicking on the blank space within issue tree view
- hide the issue details panel on logout
- hide `Focus Issue` action button